### PR TITLE
[WEB-445] Form shows larger cursor when typing on bottom

### DIFF
--- a/styles/common/_form.scss
+++ b/styles/common/_form.scss
@@ -65,11 +65,7 @@
     .form__input,
     .form__textarea {
       margin-bottom: 20px;
-      line-height: (54px - (2 * 9px));
-    }
-
-    .form__input {
-      height: 54px;
+      padding: 14px 20px;
     }
 
     .form__message {


### PR DESCRIPTION
It is not 100% fixed, but it's much better now.

<img width="540" alt="zrzut ekranu 2016-06-30 o 12 56 17" src="https://cloud.githubusercontent.com/assets/8083871/16485997/3ab85204-3ec2-11e6-9aee-f3095fbb7323.png">
