### PR TITLE
feat: separate syncano registry urls

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -6,3 +6,4 @@ export DASHBOARD_URL=
 export API_URL=
 export ANALYTICS_WRITE_KEY=
 export OPTIMIZELY_KEY=
+export SYNCANO_REGISTRY_URL=https://socket-registry.syncano.link

--- a/env.config.js
+++ b/env.config.js
@@ -13,7 +13,8 @@ const envVars = [
   'DASHBOARD_URL',
   'ANALYTICS_WRITE_KEY',
   'OPTIMIZELY_KEY',
-  'API_URL'
+  'API_URL',
+  'SYNCANO_REGISTRY_URL'
 ]
 
 const variables = envVars

--- a/src/views/sockets/sockets.service.js
+++ b/src/views/sockets/sockets.service.js
@@ -1,7 +1,7 @@
 import {action, runInAction} from 'mobx'
 
-const SOCKETS_LIST = 'https://socket-registry.syncano.space/registry/list/'
-const SOCKETS_GET = 'https://socket-registry.syncano.space/registry/get/'
+const SOCKETS_LIST = `${process.env.SYNCANO_REGISTRY_URL}/registry/list/`
+const SOCKETS_GET = `${process.env.SYNCANO_REGISTRY_URL}/registry/get/`
 
 export default class {
   @action.bound async fetch () {


### PR DESCRIPTION
Production will use https://socket-registry.syncano.space
Staging: https://socket-registry.syncano.link