### PR TITLE
Changed hardcoded 2017 year in copyright (footer) to current year

### DIFF
--- a/src/components/shared/footer.js
+++ b/src/components/shared/footer.js
@@ -3,6 +3,7 @@ import Link from '../ui/link'
 import Grid from '../ui/grid'
 import Hexagon from '../ui/hexagon'
 
+const currentYear = new Date().getFullYear()
 const Footer = () => (
   <footer className='Footer u-wrapper'>
     <div className='HiddenAtSm'>
@@ -81,7 +82,7 @@ const Footer = () => (
       </Grid>
     </div>
 
-    <div className='Copyrights'>&copy; 2017 by Syncano. All rights reserved.</div>
+    <div className='Copyrights'>&copy; {currentYear} by Syncano. All rights reserved.</div>
 
     <style jsx>{`
       .Footer {


### PR DESCRIPTION
I noticed that you have hardcoded 2017 year in the footer. Changed it to new Date().getFullYear()